### PR TITLE
Add dependency change-case

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.0.10",
     "@mdx-js/react": "^1.0.6",
+    "change-case": "^3.1.0",
     "gatsby": "^2.3.24",
     "gatsby-image": "^2.0.39",
     "gatsby-mdx": "^0.6.2",


### PR DESCRIPTION
Initial "gatsby develop" of this repo fails because of missing package `change-case`.
All I've done is add it.